### PR TITLE
Updated travis config to use Xcode7 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+osx_image: xcode7
 language: objective-c
 before_install:
   - gem install cocoapods --no-document


### PR DESCRIPTION
Use Xcode 7 image to prevent build failures